### PR TITLE
fix: Correct keyword argument in Enemy instantiation

### DIFF
--- a/ui/dm_prep_screen.py
+++ b/ui/dm_prep_screen.py
@@ -30,7 +30,7 @@ class DMPrepScreen(Screen):
         enemy_list_widget = self.ids.enemy_list_view
         enemy_list_widget.clear_widgets()
         for enemy in self.enemy_list:
-            enemy_label = Label(text=f"{enemy.name} (HP: {enemy.hp}, AC: {enemy.ac})")
+            enemy_label = Label(text=f"{enemy.name} (HP: {enemy.hp}, AC: {enemy.armor_class})")
             enemy_list_widget.add_widget(enemy_label)
 
     def add_enemy_popup(self):
@@ -64,7 +64,7 @@ class DMPrepScreen(Screen):
             new_enemy = Enemy(
                 name=name_input.text,
                 hp=int(hp_input.text),
-                ac=int(ac_input.text),
+                armor_class=int(ac_input.text),
                 initiative=int(initiative_input.text or 0),
                 attacks=[attacks_input.text],
                 notes=notes_input.text


### PR DESCRIPTION
This commit fixes a `TypeError` that occurred when creating a new enemy from the DM Prep screen.

The `Enemy` class constructor expects the keyword argument `armor_class`, but the UI was incorrectly passing `ac`.

The following changes were made:
- In `ui/dm_prep_screen.py`, the call to the `Enemy` constructor in the `save_action` function was updated to use `armor_class` instead of `ac`.
- A related bug was fixed in the `update_enemy_list_ui` method, which was trying to access `enemy.ac` instead of `enemy.armor_class` to display the enemy's details.