### PR TITLE
feat: Update server name dynamically

### DIFF
--- a/core/network_manager.py
+++ b/core/network_manager.py
@@ -67,6 +67,28 @@ class NetworkManager:
         self.sender_thread.daemon = True
         self.sender_thread.start()
 
+    def update_service_name(self, new_display_name):
+        if self.mode != 'dm' or not self.zeroconf or not self.service_info:
+            return
+
+        # Unregister the old service
+        self.zeroconf.unregister_service(self.service_info)
+
+        # Create new properties
+        properties = {b'name': new_display_name.encode('utf-8')}
+
+        # Create a new ServiceInfo object with the updated properties
+        self.service_info = ServiceInfo(
+            self.service_info.type,
+            self.service_info.name,
+            addresses=self.service_info.addresses,
+            port=self.service_info.port,
+            properties=properties
+        )
+
+        # Register the new service
+        self.zeroconf.register_service(self.service_info)
+
     def sender_loop(self):
         while self.running:
             try:

--- a/ui/dm_lobby_screen.py
+++ b/ui/dm_lobby_screen.py
@@ -167,3 +167,8 @@ class DMLobbyScreen(Screen):
                 self.app.loaded_session_data = None # Clear session data
             if hasattr(self.app, 'prepared_session_data'):
                 self.app.prepared_session_data = None # Clear prepared data
+
+    def update_session_name(self, text):
+        """Updates the server's broadcasted name."""
+        if self.network_manager.mode == 'dm':
+            self.network_manager.update_service_name(text)

--- a/ui/dmlobbyscreen.kv
+++ b/ui/dmlobbyscreen.kv
@@ -23,6 +23,7 @@
                 id: session_name_input
                 text: "DM's Spiel"
                 multiline: False
+                on_text: root.update_session_name(self.text)
 
         Label:
             text: "Verbundenen Spieler:"


### PR DESCRIPTION
This feature allows the DM to update the server name in the lobby, and the change is reflected in the Zeroconf service broadcast.

- Added `update_service_name` to `NetworkManager` to handle Zeroconf service updates without restarting the server.
- Bound the `on_text` event of the session name input in the DM lobby to a new method that calls `update_service_name`.
- This ensures that players on the local network can see the updated server name as the DM types it.