### PR TITLE
refactor: Update server name on button press for performance

### DIFF
--- a/ui/dm_lobby_screen.py
+++ b/ui/dm_lobby_screen.py
@@ -168,7 +168,10 @@ class DMLobbyScreen(Screen):
             if hasattr(self.app, 'prepared_session_data'):
                 self.app.prepared_session_data = None # Clear prepared data
 
-    def update_session_name(self, text):
+    def confirm_session_name(self):
         """Updates the server's broadcasted name."""
+        session_name = self.ids.session_name_input.text.strip()
+        if not session_name:
+            session_name = "DM's Spiel"
         if self.network_manager.mode == 'dm':
-            self.network_manager.update_service_name(text)
+            self.network_manager.update_service_name(session_name)

--- a/ui/dmlobbyscreen.kv
+++ b/ui/dmlobbyscreen.kv
@@ -23,7 +23,10 @@
                 id: session_name_input
                 text: "DM's Spiel"
                 multiline: False
-                on_text: root.update_session_name(self.text)
+            Button:
+                text: "Bestätigen"
+                size_hint_x: 0.3
+                on_press: root.confirm_session_name()
 
         Label:
             text: "Verbundenen Spieler:"


### PR DESCRIPTION
This change refactors the dynamic server name feature to improve performance. Instead of updating the Zeroconf service on every keystroke, the server name is now updated only when the user clicks a confirmation button.

- Replaced the `on_text` binding with a 'Bestätigen' (Confirm) button in the DM lobby.
- The `confirm_session_name` method is now called on button press to update the server name.