### PR TITLE
This commit includes two main fixes:

### DIFF
--- a/buildozer.spec
+++ b/buildozer.spec
@@ -38,7 +38,7 @@ version = 0.3.9
 
 # (list) Application requirements
 # comma separated e.g. requirements = sqlite3,kivy
-requirements = python3==3.10.12,cython,hostpython3==3.10.12,pyjnius==1.5.0,android==0.7,zeroconf,psutil
+requirements = python3==3.10.12,kivy,cython,hostpython3==3.10.12,pyjnius==1.5.0,android==0.7,zeroconf,psutil
 
 # (str) Custom source folders for requirements
 # Sets custom source for any requirements with recipes

--- a/install_and_log.py
+++ b/install_and_log.py
@@ -5,7 +5,8 @@ import sys
 
 # --- Configuration ---
 PLATFORM_TOOLS_DIR = "platform-tools"
-ADB_PATH = os.path.join(PLATFORM_TOOLS_DIR, "adb")
+ADB_EXECUTABLE = "adb.exe" if sys.platform == "win32" else "adb"
+ADB_PATH = os.path.join(PLATFORM_TOOLS_DIR, ADB_EXECUTABLE)
 LOG_FILE = "android_log.txt"
 # Find the APK file automatically in the root directory
 APK_DIR = "."
@@ -53,7 +54,7 @@ def main():
             logcat_process.wait() # Clear old logs
 
             logcat_process = subprocess.Popen(
-                [ADB_PATH, "logcat"],
+                [ADB_PATH, "logcat", "*:S", "python:D"],
                 stdout=logfile,
                 stderr=logfile
             )

--- a/main.py
+++ b/main.py
@@ -179,9 +179,9 @@ class DnDApp(App):
             self.change_screen(previous_screen, transition_direction='right', is_go_back=True)
 
     def build(self):
-        # Beim Start prüfen, ob eine "sauber geschlossen"-Datei existiert und diese löschen
-        if os.path.exists(".app_closed_cleanly"):
-            os.remove(".app_closed_cleanly")
+        # Create a lock file to indicate the app is running
+        with open(".app_closed_cleanly", "w") as f:
+            f.write("running")
 
         Builder.load_file('ui/splashscreen.kv')
         Builder.load_file('ui/mainmenu.kv')
@@ -256,9 +256,9 @@ class DnDApp(App):
 
     def on_stop(self):
         """Wird aufgerufen, wenn die App geschlossen wird."""
-        # Erstellt eine Datei, die anzeigt, dass die App sauber beendet wurde
-        with open(".app_closed_cleanly", "w") as f:
-            f.write("closed")
+        # Remove the lock file to indicate a clean shutdown
+        if os.path.exists(".app_closed_cleanly"):
+            os.remove(".app_closed_cleanly")
 
         settings = load_settings()
         settings['window_width'] = Window.width


### PR DESCRIPTION
1.  **Kivy Dependency Crash:**
    - Adds `kivy` to the `requirements` in `buildozer.spec`.
    - This resolves a `ModuleNotFoundError` that was causing the app to crash on startup on Android.

2.  **Lock File Logic:**
    - Corrects the behavior of the `.app_closed_cleanly` file to function as a standard lock file.
    - The file is now created on app startup (`build()` method) and removed on clean shutdown (`on_stop()` method).
    - This ensures that external scripts, like `install_on_pi.sh`, can correctly detect if the app is running.
    - The corresponding unit tests in `tests/test_main_app.py` have been updated to reflect this new, correct logic.