### PR TITLE
Pins Kivy and Cython versions in `requirements.txt`.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-kivy[base]
+kivy[base]==2.1.0
+cython<3.0
 zeroconf
 pytest
 psutil


### PR DESCRIPTION
This change pins `kivy` to version `2.1.0` and adds a `cython<3.0` dependency. This is necessary to ensure compatibility with the older system libraries (e.g., SDL2 2.0.14) present on Debian 11 (Bullseye), which the `install_on_pi.sh` script is designed for.

This resolves the C-level compilation errors that occurred when trying to build the latest version of Kivy against these older libraries.