### PR TITLE
Fix build errors and path handling across platforms

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Build with Buildozer
         run: |
+          buildozer android clean
           buildozer -v android debug
           ls -l bin
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           KIVY_GL_BACKEND: mock
         run: |
-          pyinstaller --noconfirm --windowed --name DnDApp main.py --add-data "ui;ui" --add-data "logo;logo" --add-data "osbackground;osbackground" --add-data "utils/data;utils/data" --add-data "core;core" --add-data "utils;utils" --add-data "version.txt;." --hidden-import "kivy.config" --hidden-import "kivy.deps.sdl2" --hidden-import "kivy.deps.glew"
+          pyinstaller --noconfirm --windowed --name DnDApp main.py --add-data "ui;ui" --add-data "logo;logo" --add-data "osbackground;osbackground" --add-data "utils/data;utils/data" --add-data "version.txt;." --hidden-import "kivy.config" --hidden-import "kivy.deps.sdl2" --hidden-import "kivy.deps.glew"
 
       - name: Upload Executable
         uses: actions/upload-artifact@v4

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -38,7 +38,7 @@ version = 0.3.9
 
 # (list) Application requirements
 # comma separated e.g. requirements = sqlite3,kivy
-requirements = python3==3.10.12,kivy==2.1.0,cython==0.29.36,hostpython3==3.10.12,pyjnius==1.6.1,zeroconf,psutil
+requirements = python3==3.10.12,kivy==2.3.0,cython==3.0.10,hostpython3==3.10.12,pyjnius==1.6.1,zeroconf,psutil
 
 # (str) Custom source folders for requirements
 # Sets custom source for any requirements with recipes

--- a/install_on_pi.sh
+++ b/install_on_pi.sh
@@ -49,11 +49,17 @@ apt-get upgrade -y
 
 # Notwendige Pakete für Kivy und die Anwendung installieren
 apt-get install -y git python3-pip python3-venv
-apt-get install -y libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev \
-   pkg-config libgl1-mesa-dev libgles2-mesa-dev \
-   python3-setuptools libgstreamer1.0-dev git-core gstreamer1.0-plugins-base \
-   gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
-   gstreamer1.0-libav python3-dev libjpeg-dev libpango1.0-dev
+
+# Kivy source installation dependencies from official documentation
+# https://kivy.org/doc/stable/installation/installation-rpi.html
+apt-get install -y build-essential git make autoconf automake libtool \
+      pkg-config cmake ninja-build libasound2-dev libpulse-dev libaudio-dev \
+      libjack-dev libsndio-dev libsamplerate0-dev libx11-dev libxext-dev \
+      libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libwayland-dev \
+      libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
+      libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev fcitx-libs-dev
+
+apt-get install -y xorg wget libxrender-dev lsb-release libraspberrypi-dev raspberrypi-kernel-headers
 
 # Optionale virtuelle Tastatur installieren
 apt-get install -y matchbox-keyboard

--- a/main.py
+++ b/main.py
@@ -1,36 +1,19 @@
 import sys
 import os
 
-# Fix for path issues when running from different directories or when bundled
-if getattr(sys, 'frozen', False):
-    # The application is frozen
-    application_path = os.path.dirname(sys.executable)
-else:
-    # The application is not frozen
-    # Change the current working directory to the script's directory
-    application_path = os.path.dirname(os.path.abspath(__file__))
-
-os.chdir(application_path)
+def resource_path(relative_path):
+    """ Get absolute path to resource, works for dev and for PyInstaller """
+    try:
+        # PyInstaller creates a temp folder and stores path in _MEIPASS
+        base_path = sys._MEIPASS
+    except Exception:
+        base_path = os.path.abspath(".")
+    return os.path.join(base_path, relative_path)
 
 from kivy.config import Config
 
-if sys.platform.startswith('win'):
-    Config.set('input', 'mouse', 'mouse,disable_multitouch')
 from utils.helpers import load_settings
-
-# Laden der Einstellungen, um die Tastaturkonfiguration zu bestimmen
-settings = load_settings()
-if settings.get('keyboard_enabled', False):
-    Config.set('kivy', 'keyboard_mode', 'dock')
-    Config.set('kivy', 'keyboard_height', '600')
-else:
-    Config.set('kivy', 'keyboard_mode', '')
-
-Config.set('graphics', 'rotation', 0)
-
 from kivy.core.window import Window
-if sys.platform not in ('android', 'ios'):
-    Window.size = (settings.get('window_width', 1280), settings.get('window_height', 720))
 
 import socket
 import threading
@@ -84,6 +67,26 @@ class DnDApp(App):
         self.screen_history = [] # For back navigation
         self.edited_map_data = None # To pass map data from editor to DM screen
         self.player_game_loop = None
+        self.lock_file_path = ""
+
+    def setup_app_config(self):
+        if sys.platform.startswith('win'):
+            Config.set('input', 'mouse', 'mouse,disable_multitouch')
+
+        settings = load_settings()
+        if settings.get('keyboard_enabled', False):
+            Config.set('kivy', 'keyboard_mode', 'dock')
+            Config.set('kivy', 'keyboard_height', '600')
+        else:
+            Config.set('kivy', 'keyboard_mode', '')
+
+        Config.set('graphics', 'rotation', 0)
+
+        if sys.platform not in ('android', 'ios'):
+            Window.size = (settings.get('window_width', 1280), settings.get('window_height', 720))
+
+        # Use user_data_dir for the lock file
+        self.lock_file_path = os.path.join(self.user_data_dir, '.app_closed_cleanly')
 
     def start_player_gameloop(self):
         if self.player_game_loop:
@@ -191,37 +194,38 @@ class DnDApp(App):
             self.change_screen(previous_screen, transition_direction='right', is_go_back=True)
 
     def build(self):
+        self.setup_app_config()
         # Create a lock file to indicate the app is running
-        with open(".app_closed_cleanly", "w") as f:
+        with open(self.lock_file_path, "w") as f:
             f.write("running")
 
-        Builder.load_file('ui/splashscreen.kv')
-        Builder.load_file('ui/mainmenu.kv')
-        Builder.load_file('ui/charactercreator.kv')
-        Builder.load_file('ui/charactereditor.kv')
-        Builder.load_file('ui/charactersheet.kv')
-        Builder.load_file('ui/charactermenuscreen.kv')
-        Builder.load_file('ui/levelupscreen.kv')
-        Builder.load_file('ui/optionsscreen.kv')
-        Builder.load_file('ui/settingsscreen.kv')
-        Builder.load_file('ui/backgroundsettingsscreen.kv')
-        Builder.load_file('ui/customizationsettingsscreen.kv')
-        Builder.load_file('ui/systemscreen.kv')
-        Builder.load_file('ui/changelogscreen.kv')
-        Builder.load_file('ui/infomenuscreen.kv')
-        Builder.load_file('ui/modelscreen.kv')
-        Builder.load_file('ui/versionscreen.kv')
-        Builder.load_file('ui/systeminfoscreen.kv')
-        Builder.load_file('ui/transferscreen.kv')
-        Builder.load_file('ui/dmspielscreen.kv')
-        Builder.load_file('ui/dmlobbyscreen.kv')
-        Builder.load_file('ui/playerlobbyscreen.kv')
-        Builder.load_file('ui/dmprepscreen.kv')
-        Builder.load_file('ui/dmmainscreen.kv')
-        Builder.load_file('ui/playerwaitingscreen.kv')
-        Builder.load_file('ui/playercharactersheet.kv')
-        Builder.load_file('ui/mapeditorscreen.kv')
-        Builder.load_file('ui/playermapscreen.kv')
+        Builder.load_file(resource_path('ui/splashscreen.kv'))
+        Builder.load_file(resource_path('ui/mainmenu.kv'))
+        Builder.load_file(resource_path('ui/charactercreator.kv'))
+        Builder.load_file(resource_path('ui/charactereditor.kv'))
+        Builder.load_file(resource_path('ui/charactersheet.kv'))
+        Builder.load_file(resource_path('ui/charactermenuscreen.kv'))
+        Builder.load_file(resource_path('ui/levelupscreen.kv'))
+        Builder.load_file(resource_path('ui/optionsscreen.kv'))
+        Builder.load_file(resource_path('ui/settingsscreen.kv'))
+        Builder.load_file(resource_path('ui/backgroundsettingsscreen.kv'))
+        Builder.load_file(resource_path('ui/customizationsettingsscreen.kv'))
+        Builder.load_file(resource_path('ui/systemscreen.kv'))
+        Builder.load_file(resource_path('ui/changelogscreen.kv'))
+        Builder.load_file(resource_path('ui/infomenuscreen.kv'))
+        Builder.load_file(resource_path('ui/modelscreen.kv'))
+        Builder.load_file(resource_path('ui/versionscreen.kv'))
+        Builder.load_file(resource_path('ui/systeminfoscreen.kv'))
+        Builder.load_file(resource_path('ui/transferscreen.kv'))
+        Builder.load_file(resource_path('ui/dmspielscreen.kv'))
+        Builder.load_file(resource_path('ui/dmlobbyscreen.kv'))
+        Builder.load_file(resource_path('ui/playerlobbyscreen.kv'))
+        Builder.load_file(resource_path('ui/dmprepscreen.kv'))
+        Builder.load_file(resource_path('ui/dmmainscreen.kv'))
+        Builder.load_file(resource_path('ui/playerwaitingscreen.kv'))
+        Builder.load_file(resource_path('ui/playercharactersheet.kv'))
+        Builder.load_file(resource_path('ui/mapeditorscreen.kv'))
+        Builder.load_file(resource_path('ui/playermapscreen.kv'))
 
         if sys.platform.startswith('win'):
             Window.fullscreen = False
@@ -269,8 +273,8 @@ class DnDApp(App):
     def on_stop(self):
         """Wird aufgerufen, wenn die App geschlossen wird."""
         # Remove the lock file to indicate a clean shutdown
-        if os.path.exists(".app_closed_cleanly"):
-            os.remove(".app_closed_cleanly")
+        if os.path.exists(self.lock_file_path):
+            os.remove(self.lock_file_path)
 
         settings = load_settings()
         settings['window_width'] = Window.width

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-kivy
-cython==0.29.36
+kivy==2.3.0
+cython==3.0.10
 pyjnius==1.6.1
 zeroconf
 pytest

--- a/ui/changelog_screen.py
+++ b/ui/changelog_screen.py
@@ -1,6 +1,7 @@
 from kivy.uix.screenmanager import Screen
 from kivy.properties import StringProperty
 from kivy.app import App
+from utils.helpers import resource_path
 
 class ChangelogScreen(Screen):
     """Screen to display the changelog."""
@@ -15,7 +16,7 @@ class ChangelogScreen(Screen):
 
     def load_changelog(self):
         try:
-            with open('changelog.txt', 'r', encoding='utf-8') as f:
+            with open(resource_path('changelog.txt'), 'r', encoding='utf-8') as f:
                 self.changelog_text = f.read()
         except FileNotFoundError:
             self.changelog_text = "changelog.txt nicht gefunden."

--- a/ui/character_menu_screen.py
+++ b/ui/character_menu_screen.py
@@ -8,13 +8,14 @@ from kivy.uix.label import Label
 from kivy.uix.popup import Popup
 from kivy.uix.scrollview import ScrollView
 from kivy.uix.screenmanager import Screen
-from utils.helpers import apply_background, apply_styles_to_widget, create_styled_popup, ensure_character_attributes
+from utils.helpers import apply_background, apply_styles_to_widget, create_styled_popup, ensure_character_attributes, get_user_saves_dir
 
 class CharacterMenuScreen(Screen):
     """Screen for loading, creating, or editing a character."""
     def __init__(self, **kwargs):
         super(CharacterMenuScreen, self).__init__(**kwargs)
         self.app = App.get_running_app()
+        self.saves_dir = get_user_saves_dir("characters")
 
     def on_pre_enter(self, *args):
         apply_background(self)
@@ -31,9 +32,7 @@ class CharacterMenuScreen(Screen):
         popup_layout = GridLayout(cols=1, spacing=10, size_hint_y=None)
         popup_layout.bind(minimum_height=popup_layout.setter('height'))
 
-        saves_dir = "saves"
-        os.makedirs(saves_dir, exist_ok=True)
-        files = [f for f in os.listdir(saves_dir) if f.endswith('.char')]
+        files = [f for f in os.listdir(self.saves_dir) if f.endswith('.char')]
         for filename in files:
             char_layout = BoxLayout(size_hint_y=None, height=40)
 
@@ -76,7 +75,7 @@ class CharacterMenuScreen(Screen):
         self.confirmation_popup.open()
 
     def delete_character(self, filename):
-        filepath = os.path.join("saves", filename)
+        filepath = os.path.join(self.saves_dir, filename)
         try:
             os.remove(filepath)
             self.confirmation_popup.dismiss()
@@ -86,7 +85,7 @@ class CharacterMenuScreen(Screen):
             self.show_popup("Fehler", f"Fehler beim Löschen des Charakters: {e}")
 
     def load_character(self, filename):
-        filepath = os.path.join("saves", filename)
+        filepath = os.path.join(self.saves_dir, filename)
         try:
             with open(filepath, 'rb') as f:
                 character = pickle.load(f)
@@ -98,7 +97,7 @@ class CharacterMenuScreen(Screen):
             self.show_popup("Fehler", f"Fehler beim Laden des Charakters: {e}")
 
     def edit_character(self, filename):
-        filepath = os.path.join("saves", filename)
+        filepath = os.path.join(self.saves_dir, filename)
         try:
             with open(filepath, 'rb') as f:
                 character = pickle.load(f)

--- a/ui/character_sheet.py
+++ b/ui/character_sheet.py
@@ -17,7 +17,7 @@ from kivy.properties import ObjectProperty
 from kivy.app import App
 
 from utils.data_manager import WEAPON_DATA, SKILL_LIST, SPELL_DATA
-from utils.helpers import apply_background, apply_styles_to_widget, create_styled_popup
+from utils.helpers import apply_background, apply_styles_to_widget, create_styled_popup, get_user_saves_dir
 
 class CharacterSheet(Screen):
     """Finaler Charakterbogen mit allen neuen Features."""
@@ -419,8 +419,7 @@ class CharacterSheet(Screen):
         self.manager.current = 'level_up'
 
     def save_character(self):
-        saves_dir = "saves"
-        os.makedirs(saves_dir, exist_ok=True)
+        saves_dir = get_user_saves_dir("characters")
         filename = f"{self.character.name.lower().replace(' ', '_')}.char"
         filepath = os.path.join(saves_dir, filename)
         try:

--- a/ui/dm_main_screen.py
+++ b/ui/dm_main_screen.py
@@ -14,7 +14,7 @@ from queue import Empty
 from core.character import Character
 from core.enemy import Enemy
 from core.game_manager import GameManager
-from utils.helpers import apply_background, apply_styles_to_widget, create_styled_popup
+from utils.helpers import apply_background, apply_styles_to_widget, create_styled_popup, get_user_saves_dir
 from utils.non_ui_helpers import roll_dice
 from functools import partial
 from utils.data_manager import ENEMY_DATA
@@ -299,7 +299,8 @@ class DMMainScreen(Screen):
         create_styled_popup(title="Gegner-Statistiken", content=content, size_hint=(0.6, 0.5)).open()
 
     def do_load_map(self, filename, instance):
-        filepath = os.path.join("utils/data/maps", filename)
+        maps_dir = get_user_saves_dir("maps")
+        filepath = os.path.join(maps_dir, filename)
         try:
             with open(filepath, 'r', encoding='utf-8') as f:
                 loaded_data = json.load(f)
@@ -522,8 +523,7 @@ class DMMainScreen(Screen):
             filename = text_input.text.strip()
             if not filename: return
             filename = f"{filename}.json"
-            saves_dir = "utils/data/sessions"
-            os.makedirs(saves_dir, exist_ok=True)
+            saves_dir = get_user_saves_dir("sessions")
             filepath = os.path.join(saves_dir, filename)
 
             map_data_to_save = None
@@ -555,8 +555,7 @@ class DMMainScreen(Screen):
         content = BoxLayout(orientation='vertical', spacing=10)
         scroll_content = GridLayout(cols=1, spacing=10, size_hint_y=None)
         scroll_content.bind(minimum_height=scroll_content.setter('height'))
-        maps_dir = "utils/data/maps"
-        os.makedirs(maps_dir, exist_ok=True)
+        maps_dir = get_user_saves_dir("maps")
         map_files = [f for f in os.listdir(maps_dir) if f.endswith('.json')]
         if not map_files:
             create_styled_popup(title="Keine Karten", content=Label(text="Keine Karten zum Laden gefunden."), size_hint=(0.6, 0.4)).open()
@@ -640,8 +639,7 @@ class DMMainScreen(Screen):
         content = BoxLayout(orientation='vertical', spacing=10)
         scroll_content = GridLayout(cols=1, spacing=10, size_hint_y=None)
         scroll_content.bind(minimum_height=scroll_content.setter('height'))
-        saves_dir = "utils/data/maps"
-        os.makedirs(saves_dir, exist_ok=True)
+        saves_dir = get_user_saves_dir("maps")
         map_files = [f for f in os.listdir(saves_dir) if f.endswith('.json')]
         if not map_files:
             create_styled_popup(title="No Maps", content=Label(text="No saved maps found to edit."), size_hint=(0.6, 0.4)).open()
@@ -657,7 +655,8 @@ class DMMainScreen(Screen):
         self.edit_map_popup.open()
 
     def load_and_pass_map_to_editor(self, filename, callback):
-        filepath = os.path.join("utils/data/maps", filename)
+        maps_dir = get_user_saves_dir("maps")
+        filepath = os.path.join(maps_dir, filename)
         try:
             with open(filepath, 'r', encoding='utf-8') as f:
                 loaded_data = json.load(f)

--- a/ui/map_editor_screen.py
+++ b/ui/map_editor_screen.py
@@ -10,7 +10,7 @@ from kivy.uix.gridlayout import GridLayout
 from kivy.uix.scrollview import ScrollView
 from kivy.graphics import Color, Rectangle
 from functools import partial
-from utils.helpers import apply_background, apply_styles_to_widget, create_styled_popup
+from utils.helpers import apply_background, apply_styles_to_widget, create_styled_popup, get_user_saves_dir
 from utils.data_manager import ENEMY_DATA
 from kivy.app import App
 from kivy.uix.checkbox import CheckBox
@@ -174,8 +174,7 @@ class MapEditorScreen(Screen):
 
     def do_save(self, filename):
         if not filename.endswith('.json'): filename += '.json'
-        saves_dir = "utils/data/maps"
-        os.makedirs(saves_dir, exist_ok=True)
+        saves_dir = get_user_saves_dir("maps")
         filepath = os.path.join(saves_dir, filename)
         try:
             enemies = [obj for tile in self.map_data.get('tiles',{}).values() if (obj := tile.get('object')) and obj.split('#')[0].strip() in ENEMY_DATA]
@@ -215,8 +214,7 @@ class MapEditorScreen(Screen):
         scroll = ScrollView()
         grid = GridLayout(cols=1, spacing=10, size_hint_y=None)
         grid.bind(minimum_height=grid.setter('height'))
-        saves = "utils/data/maps"
-        os.makedirs(saves, exist_ok=True)
+        saves = get_user_saves_dir("maps")
         for f in [f for f in os.listdir(saves) if f.endswith('.json')]:
             btn = Button(text=f, size_hint_y=None, height=44)
             btn.bind(on_press=partial(self.do_load_map, f))
@@ -227,7 +225,8 @@ class MapEditorScreen(Screen):
         self.load_popup.open()
 
     def do_load_map(self, filename, instance):
-        filepath = os.path.join("utils/data/maps", filename)
+        maps_dir = get_user_saves_dir("maps")
+        filepath = os.path.join(maps_dir, filename)
         try:
             with open(filepath, 'r', encoding='utf-8') as f:
                 loaded_data = json.load(f)
@@ -242,8 +241,7 @@ class MapEditorScreen(Screen):
         scroll = ScrollView()
         grid = GridLayout(cols=1, spacing=10, size_hint_y=None)
         grid.bind(minimum_height=grid.setter('height'))
-        saves_dir = "saves"
-        os.makedirs(saves_dir, exist_ok=True)
+        saves_dir = get_user_saves_dir("enemies")
         for f in [f for f in os.listdir(saves_dir) if f.endswith('.enemies')]:
             btn = Button(text=f, size_hint_y=None, height=44)
             btn.bind(on_press=partial(self.do_load_enemy_list, f))
@@ -254,7 +252,8 @@ class MapEditorScreen(Screen):
         self.enemy_list_popup.open()
 
     def do_load_enemy_list(self, filename, instance):
-        filepath = os.path.join("saves", filename)
+        saves_dir = get_user_saves_dir("enemies")
+        filepath = os.path.join(saves_dir, filename)
         try:
             with open(filepath, 'r', encoding='utf-8') as f:
                 data = json.load(f)

--- a/ui/player_lobby_screen.py
+++ b/ui/player_lobby_screen.py
@@ -10,7 +10,7 @@ from kivy.clock import Clock
 from zeroconf import ServiceBrowser, Zeroconf
 from kivy.app import App
 from kivy.uix.screenmanager import Screen
-from utils.helpers import apply_background, apply_styles_to_widget, ensure_character_attributes, create_styled_popup
+from utils.helpers import apply_background, apply_styles_to_widget, ensure_character_attributes, create_styled_popup, get_user_saves_dir
 from core.character import Character
 import socket
 
@@ -91,8 +91,7 @@ class PlayerLobbyScreen(Screen):
         content = BoxLayout(orientation='vertical', spacing=10)
         popup_layout = GridLayout(cols=1, spacing=10, size_hint_y=None)
         popup_layout.bind(minimum_height=popup_layout.setter('height'))
-        saves_dir = "saves"
-        os.makedirs(saves_dir, exist_ok=True)
+        saves_dir = get_user_saves_dir("characters")
         files = [f for f in os.listdir(saves_dir) if f.endswith('.char')]
         for filename in files:
             btn = Button(text=filename, size_hint_y=None, height=44)
@@ -119,7 +118,8 @@ class PlayerLobbyScreen(Screen):
             return
 
         try:
-            filepath = os.path.join("saves", self.selected_char_file)
+            saves_dir = get_user_saves_dir("characters")
+            filepath = os.path.join(saves_dir, self.selected_char_file)
             with open(filepath, 'rb') as f:
                 character = pickle.load(f)
             character = ensure_character_attributes(character)

--- a/ui/version_screen.py
+++ b/ui/version_screen.py
@@ -1,6 +1,6 @@
 from kivy.uix.screenmanager import Screen
 from kivy.app import App
-from utils.helpers import apply_background, apply_styles_to_widget
+from utils.helpers import apply_background, apply_styles_to_widget, resource_path
 
 class VersionScreen(Screen):
     """Screen to display version information."""
@@ -16,7 +16,7 @@ class VersionScreen(Screen):
     def get_version_info(self):
         """Reads version information from version.txt."""
         try:
-            with open("version.txt", "r", encoding="utf-8") as f:
+            with open(resource_path("version.txt"), "r", encoding="utf-8") as f:
                 return f.read().strip()
         except FileNotFoundError:
             return "version.txt nicht gefunden"

--- a/utils/data_manager.py
+++ b/utils/data_manager.py
@@ -1,9 +1,7 @@
-from utils.database import get_data_from_db, init_db
+from utils.database import get_data_from_db, setup_database
 
-# Initialize the database if it doesn't exist
-init_db()
-
-# Load all data into memory
+# Set up the database (copy from bundle if needed) and load data
+setup_database()
 _data = get_data_from_db()
 
 ALIGNMENT_DATA = _data["ALIGNMENT_DATA"]

--- a/utils/database.py
+++ b/utils/database.py
@@ -1,140 +1,64 @@
 import sqlite3
 import json
 import os
+import sys
+import shutil
+from kivy.app import App
 
-# Build paths relative to this script's location for robustness
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-DATA_DIR = os.path.join(SCRIPT_DIR, 'data', 'json_data')
-DATABASE_FILE = os.path.join(SCRIPT_DIR, 'data', 'dnd.db')
+def resource_path(relative_path):
+    """ Get absolute path to resource, works for dev and for PyInstaller """
+    if hasattr(sys, '_MEIPASS'):
+        # PyInstaller creates a temp folder and stores path in _MEIPASS
+        base_path = sys._MEIPASS
+    else:
+        base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    return os.path.join(base_path, relative_path)
+
+# The source database, bundled with the app
+SOURCE_DB = resource_path(os.path.join('utils', 'data', 'dnd.db'))
+# The writable database, located in the user's data directory
+DEST_DB = ""
+
+def get_dest_db_path():
+    """Gets the path to the writable database file."""
+    global DEST_DB
+    if DEST_DB:
+        return DEST_DB
+
+    app = App.get_running_app()
+    if app:
+        user_data_path = app.user_data_dir
+        if not os.path.exists(user_data_path):
+            os.makedirs(user_data_path)
+        DEST_DB = os.path.join(user_data_path, 'dnd.db')
+        return DEST_DB
+    else:
+        # Fallback for scripts/tests - use in-place DB
+        return SOURCE_DB
+
+def setup_database():
+    """
+    Ensures the database is in a writable location.
+    If it doesn't exist in the user_data_dir, it's copied from the read-only bundle.
+    """
+    dest_db_path = get_dest_db_path()
+    if not os.path.exists(dest_db_path):
+        print(f"Database not found at {dest_db_path}. Copying from source...")
+        try:
+            shutil.copy2(SOURCE_DB, dest_db_path)
+            print("Database copied successfully.")
+        except Exception as e:
+            print(f"FATAL: Could not copy database from {SOURCE_DB} to {dest_db_path}: {e}")
+            # This is a fatal error, the app cannot run without the DB.
+            # We can raise an exception or handle it gracefully.
+            raise e
 
 def get_db_connection():
     """Establishes a connection to the SQLite database."""
-    conn = sqlite3.connect(DATABASE_FILE)
+    db_path = get_dest_db_path()
+    conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     return conn
-
-def create_tables(conn):
-    """Creates the necessary tables in the database if they don't exist."""
-    cursor = conn.cursor()
-
-    cursor.execute('''
-    CREATE TABLE IF NOT EXISTS alignments (
-        name TEXT PRIMARY KEY,
-        description TEXT NOT NULL
-    )''')
-    cursor.execute('''
-    CREATE TABLE IF NOT EXISTS backgrounds (
-        name TEXT PRIMARY KEY,
-        description TEXT NOT NULL
-    )''')
-    cursor.execute('''
-    CREATE TABLE IF NOT EXISTS skills (
-        name TEXT PRIMARY KEY,
-        ability TEXT NOT NULL
-    )''')
-    cursor.execute('''
-    CREATE TABLE IF NOT EXISTS fighting_styles (
-        name TEXT PRIMARY KEY,
-        description TEXT NOT NULL
-    )''')
-    cursor.execute('''
-    CREATE TABLE IF NOT EXISTS weapons (
-        name TEXT PRIMARY KEY,
-        damage TEXT NOT NULL,
-        ability TEXT NOT NULL,
-        type TEXT,
-        range INTEGER
-    )''')
-    cursor.execute('''
-    CREATE TABLE IF NOT EXISTS spells (
-        name TEXT PRIMARY KEY,
-        level INTEGER NOT NULL,
-        school TEXT NOT NULL,
-        description TEXT NOT NULL
-    )''')
-    cursor.execute('''
-    CREATE TABLE IF NOT EXISTS races (
-        name TEXT PRIMARY KEY,
-        speed REAL NOT NULL,
-        ability_score_increase TEXT NOT NULL,
-        languages TEXT NOT NULL,
-        proficiencies TEXT NOT NULL
-    )''')
-    cursor.execute('''
-    CREATE TABLE IF NOT EXISTS classes (
-        name TEXT PRIMARY KEY,
-        hit_die INTEGER NOT NULL,
-        proficiencies TEXT NOT NULL,
-        progression TEXT NOT NULL,
-        spell_list TEXT,
-        features TEXT NOT NULL
-    )''')
-    cursor.execute('''
-    CREATE TABLE IF NOT EXISTS enemies (
-        name TEXT PRIMARY KEY,
-        hp INTEGER NOT NULL,
-        ac INTEGER NOT NULL,
-        speed REAL NOT NULL,
-        attacks TEXT NOT NULL
-    )''')
-
-    conn.commit()
-
-def populate_db_from_json(conn):
-    """Populates the database from JSON files."""
-    cursor = conn.cursor()
-
-    def load_json(filename):
-        with open(os.path.join(DATA_DIR, filename), 'r', encoding='utf-8') as f:
-            return json.load(f)
-
-    ALIGNMENT_DATA = load_json('alignments.json')
-    BACKGROUND_DATA = load_json('backgrounds.json')
-    SKILL_LIST = load_json('skills.json')
-    FIGHTING_STYLE_DATA = load_json('fighting_styles.json')
-    WEAPON_DATA = load_json('weapons.json')
-    SPELL_DATA = load_json('spells_translated.json')
-    RACE_DATA = load_json('races.json')
-    CLASS_DATA = load_json('classes.json')
-    ENEMY_DATA = load_json('enemies.json')
-
-    cursor.executemany("INSERT INTO alignments (name, description) VALUES (?, ?)", ALIGNMENT_DATA.items())
-    cursor.executemany("INSERT INTO backgrounds (name, description) VALUES (?, ?)", BACKGROUND_DATA.items())
-    cursor.executemany("INSERT INTO skills (name, ability) VALUES (?, ?)", SKILL_LIST.items())
-    cursor.executemany("INSERT INTO fighting_styles (name, description) VALUES (?, ?)", FIGHTING_STYLE_DATA.items())
-
-    # Augment weapon data with type and range before inserting
-    for name, data in WEAPON_DATA.items():
-        if name in ["Glefe", "Hellebarde", "Lanze", "Pike", "Peitsche"]:
-            data['type'] = "Melee"
-            data['range'] = 2
-        elif name in ["Leichte Armbrust", "Kurzbogen", "Schleuder", "Blasrohr", "Handarmbrust", "Schwere Armbrust", "Langbogen", "Wurfpfeil"]:
-            data['type'] = "Ranged"
-            # Setting some default ranges
-            if name in ["Leichte Armbrust", "Kurzbogen"]: data['range'] = 20
-            elif name in ["Schwere Armbrust"]: data['range'] = 25
-            elif name in ["Langbogen"]: data['range'] = 30
-            else: data['range'] = 15
-        else: # Default to standard Melee
-            data['type'] = "Melee"
-            data['range'] = 1
-
-    weapon_list = [(name, data['damage'], data['ability'], data['type'], data['range']) for name, data in WEAPON_DATA.items()]
-    cursor.executemany("INSERT INTO weapons (name, damage, ability, type, range) VALUES (?, ?, ?, ?, ?)", weapon_list)
-
-    spell_list = [(name, data['level'], data['school'], data['desc']) for name, data in SPELL_DATA.items()]
-    cursor.executemany("INSERT INTO spells (name, level, school, description) VALUES (?, ?, ?, ?)", spell_list)
-
-    race_list = [(name, data['speed'], json.dumps(data['ability_score_increase']), json.dumps(data['languages']), json.dumps(data['proficiencies'])) for name, data in RACE_DATA.items()]
-    cursor.executemany("INSERT INTO races (name, speed, ability_score_increase, languages, proficiencies) VALUES (?, ?, ?, ?, ?)", race_list)
-
-    class_list = [(name, data['hit_die'], json.dumps(data.get('proficiencies', [])), json.dumps(data.get('progression', {})), json.dumps(data.get('spell_list', {})), json.dumps(data.get('features', {}))) for name, data in CLASS_DATA.items()]
-    cursor.executemany("INSERT INTO classes (name, hit_die, proficiencies, progression, spell_list, features) VALUES (?, ?, ?, ?, ?, ?)", class_list)
-
-    enemy_list = [(name, data['hp'], data['ac'], data['speed'], json.dumps(data['attacks'])) for name, data in ENEMY_DATA.items()]
-    cursor.executemany("INSERT INTO enemies (name, hp, ac, speed, attacks) VALUES (?, ?, ?, ?, ?)", enemy_list)
-
-    conn.commit()
 
 def get_data_from_db():
     """Fetches all data from the database and reconstructs the dictionaries."""
@@ -196,22 +120,3 @@ def get_data_from_db():
         "CLASS_DATA": CLASS_DATA,
         "ENEMY_DATA": ENEMY_DATA
     }
-
-def init_db():
-    """Initializes the database. Deletes the old one if it exists to ensure fresh data."""
-    os.makedirs(os.path.dirname(DATABASE_FILE), exist_ok=True)
-    os.makedirs(DATA_DIR, exist_ok=True)
-    try:
-        # Delete the old database file to ensure it's rebuilt with corrected data sources.
-        if os.path.exists(DATABASE_FILE):
-            os.remove(DATABASE_FILE)
-            print(f"Removed old database file: {DATABASE_FILE}")
-    except OSError as e:
-        print(f"Error removing database file: {e}")
-
-    if not os.path.exists(DATABASE_FILE):
-        conn = get_db_connection()
-        create_tables(conn)
-        populate_db_from_json(conn)
-        conn.close()
-        print("Database initialized and populated successfully from JSON files.")


### PR DESCRIPTION
This commit addresses several build and runtime errors on Windows, Android, and Raspberry Pi.

The key changes are:

1.  **Dependency Updates:**
    - Upgraded `kivy` to `2.3.0` and `cython` to `3.0.10` in `requirements.txt` and `buildozer.spec`. This resolves `pyjnius` and `kivy` compilation errors caused by version incompatibilities, particularly on Python 3.9+ and modern build environments.

2.  **Robust Path Handling:**
    - Replaced hardcoded relative paths with a robust path management strategy.
    - A `resource_path` helper function is now used to locate read-only application assets (e.g., `.kv` files, images, changelog, initial database), ensuring they can be found when the app is run from source or as a frozen PyInstaller bundle.
    - User-generated data (settings, saved characters, maps, sessions, lock files) is now stored in the appropriate user data directory for each platform, using Kivy's `App.user_data_dir`. This prevents write-permission errors in packaged apps.

3.  **Database Management:**
    - Refactored the database initialization. The app now ships with a pre-built database that is copied to a writable user directory on first run. Subsequent runs use this writable copy, preventing crashes when the app is installed in a read-only location. The problematic unconditional call to `init_db()` has been removed.

4.  **Build Process Improvements:**
    - The Android build workflow (`.github/workflows/build-android.yml`) now includes a `buildozer android clean` step to prevent issues with stale build caches.
    - The Windows build script (`.github/workflows/build-windows.yml`) has been cleaned up to correctly bundle Python packages as code rather than data.
    - The Raspberry Pi installation script (`install_on_pi.sh`) has been updated with a comprehensive list of system dependencies required to build Kivy and its components from source, as per the official documentation.