### PR TITLE
Fix Android build failure by removing trailing commas in buildozer.spec

### DIFF
--- a/buildozer.spec
+++ b/buildozer.spec
@@ -19,10 +19,10 @@ source.include_exts = py,png,jpg,kv,db,json,txt,enemies,session,char
 source.include_patterns = assets/*,data/*
 
 # (list) Source files to exclude (let empty to not exclude anything)
-source.exclude_exts = install_and_log.py, install_on_pi.sh, README.md,
+source.exclude_exts = install_and_log.py, install_on_pi.sh, README.md
 
 # (list) List of directory to exclude (let empty to not exclude anything)
-source.exclude_dirs = tests, 
+source.exclude_dirs = tests
 
 # (list) List of exclusions using pattern matching
 # Do not prefix with './'


### PR DESCRIPTION
The Android build was failing with an `IndexError: string index out of range` in the buildozer script. This was caused by trailing commas in the `source.exclude_exts` and `source.exclude_dirs` lists in the `buildozer.spec` file.

This commit removes the trailing commas, which allows the buildozer script to correctly parse the exclusion lists and prevents the build from crashing.