### PR TITLE
Fix Android build and test environment

### DIFF
--- a/buildozer.spec
+++ b/buildozer.spec
@@ -38,7 +38,7 @@ version = 0.3.9
 
 # (list) Application requirements
 # comma separated e.g. requirements = sqlite3,kivy
-requirements = python3==3.10.12,pygame,cython,hostpython3==3.10.12,pyjnius==1.5.0,android==0.7,zeroconf,kivy
+requirements = python3==3.10.12,hostpython3==3.10.12,kivy==2.3.0,pygame,cython==0.29.36,pyjnius==1.6.1,android==0.7,zeroconf,psutil,pytest
 
 # (str) Custom source folders for requirements
 # Sets custom source for any requirements with recipes
@@ -111,6 +111,7 @@ android.permissions = android.permission.READ_EXTERNAL_STORAGE, android.permissi
 #android.sdk = 20
 
 # (str) Android NDK version to use
+android.ndk_version = 26b
 #android.ndk = 23b
 
 # (int) Android NDK API to use. This is the minimum API your app will support, it should usually match android.minapi.
@@ -322,7 +323,7 @@ android.allow_backup = True
 #p4a.fork = kivy
 
 # (str) python-for-android branch to use, defaults to master
-#p4a.branch = master
+p4a.branch = v2024.01.21
 
 # (str) python-for-android specific commit to use, defaults to HEAD, must be within p4a.branch
 #p4a.commit = HEAD

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
-kivy==2.1.0
+kivy==2.3.0
 zeroconf
 pytest
 psutil
 cython==0.29.36
-pyjnius==1.4.1
+pyjnius==1.6.1
 pygame


### PR DESCRIPTION
This commit fixes the Android build and test environment by:

- Updating `buildozer.spec` to use a stable version of `python-for-android` (v2024.01.21) to fix the `harfbuzz` compilation error.
- Updating `kivy` to version 2.3.0 in `buildozer.spec` and `requirements_dev.txt` to ensure compatibility with Python 3.12.
- Updating `pyjnius` to version 1.6.1 in `buildozer.spec` and `requirements_dev.txt` to match the version used by `python-for-android v2024.01.21`.
- Adding `pytest` to the `requirements` in `buildozer.spec` to ensure it's included in the build.