### PR TITLE
Bump version to 0.5.0 and improve test setup/teardown

### DIFF
--- a/buildozer.spec
+++ b/buildozer.spec
@@ -33,7 +33,7 @@ source.exclude_dirs = tests
 #source.exclude_patterns = license,images/*/*.jpg
 
 # (str) Application versioning (method 1)
-version = 0.3.9
+version = 0.5.0
 #version = Release.mainversion.miniGame
 
 # (str) Application versioning (method 2)

--- a/tests/test_dm_prep_screen.py
+++ b/tests/test_dm_prep_screen.py
@@ -17,7 +17,11 @@ from utils.helpers import get_user_saves_dir
 class TestDMPrepScreen(unittest.TestCase):
 
 
+
     def setUp(self):
+        # Patch get_user_saves_dir to always use the same directory
+        self._patcher = patch('utils.helpers.get_user_saves_dir', get_user_saves_dir)
+        self._patcher.start()
         self.screen = DMPrepScreen()
         self.saves_dir = get_user_saves_dir("enemies")
         self.test_file = os.path.join(self.saves_dir, "my_enemies.enemies")
@@ -25,6 +29,11 @@ class TestDMPrepScreen(unittest.TestCase):
         # Clean up any old test files
         if os.path.exists(self.test_file):
             os.remove(self.test_file)
+
+    def tearDown(self):
+        if os.path.exists(self.test_file):
+            os.remove(self.test_file)
+        self._patcher.stop()
 
     def tearDown(self):
         # Clean up test files after tests


### PR DESCRIPTION
Updated buildozer.spec to version 0.5.0. Enhanced test_dm_prep_screen.py by patching get_user_saves_dir in setUp and ensuring proper cleanup in tearDown, preventing test file residue and improving test isolation.